### PR TITLE
fix(UX-improvements-Now-user-can-click-the-tab-and-go-back-to-data-gr…

### DIFF
--- a/src/components/testlist/tcs-detail.tsx
+++ b/src/components/testlist/tcs-detail.tsx
@@ -1,4 +1,11 @@
-import { Grid, List, ListItem, ListItemText, Tooltip, Typography } from "@mui/material"
+import {
+  Grid,
+  List,
+  ListItem,
+  ListItemText,
+  Tooltip,
+  Typography,
+} from "@mui/material"
 import React from "react"
 import { Close, Edit } from "@mui/icons-material"
 import { makeStyles } from "@mui/styles"
@@ -24,24 +31,33 @@ export interface TcsDetailProps {
 const useStyles = makeStyles(() => ({
   listItem: {
     margin: 8,
-    wordBreak: "break-all"
+    wordBreak: "break-all",
   },
 }))
-
 
 export default function TcsDetail(props: TcsDetailProps) {
   const classes = useStyles()
   const [editTest, setEditTest] = React.useState(props.close == undefined)
   const [value, setValue] = React.useState(0)
   const [valueRes, setResValue] = React.useState(0)
-  const { loading, error, data: tc } = useQuery<TestcaseData>(GET_TC, {
-    variables: { id: props.tc }
+  const {
+    loading,
+    error,
+    data: tc,
+  } = useQuery<TestcaseData>(GET_TC, {
+    variables: { id: props.tc },
   })
 
   if (loading) return <Loading />
   if (error) return <ErrorView msg={error.message} />
   if (tc == null || tc.testCase == null || tc.testCase.length == null) {
-    return <Empty message={"Uh! Oh! This test case doesn't exist anymore."} doc={"https://docs.keploy.io"} image={EmptyImg}/>
+    return (
+      <Empty
+        message={"Uh! Oh! This test case doesn't exist anymore."}
+        doc={"https://docs.keploy.io"}
+        image={EmptyImg}
+      />
+    )
   }
 
   const data = tc.testCase[0]
@@ -55,50 +71,70 @@ export default function TcsDetail(props: TcsDetailProps) {
   }
 
   return (
-    <Grid sx={{minHeight: '80vh'}} >
+    <Grid sx={{ minHeight: "80vh" }}>
       {!editTest && (
         <React.Fragment>
           <Grid container>
             <Grid item xs={6}>
-              <AntTabs value={value} onChange={handleChange} aria-label="basic tabs">
+              <AntTabs
+                value={value}
+                onChange={handleChange}
+                aria-label="basic tabs"
+              >
                 <AntTab label="Response" {...a11yProps(0)} />
                 <AntTab label="Request" {...a11yProps(1)} />
                 <AntTab label="Dependency" {...a11yProps(2)} />
                 <AntTab label="Raw Events" {...a11yProps(3)} />
               </AntTabs>
             </Grid>
-            <Grid item xs={6} container justifyContent={"flex-end"} alignItems={"center"}>
+            <Grid
+              item
+              xs={6}
+              container
+              justifyContent={"flex-end"}
+              alignItems={"center"}
+            >
               <Tooltip title={"Edit Test Case"}>
-                <Edit sx={{
-                  marginRight: 2,
-                  color: "#d2d2d2",
-                  ':hover': {
-                    color: 'warning.main',
-                  },
-                }}
-                      onClick={()=> {
-                        setEditTest(true)
-                        setValue(0)
-                      }}
+                <Edit
+                  sx={{
+                    marginRight: 2,
+                    color: "#d2d2d2",
+                    ":hover": {
+                      color: "warning.main",
+                    },
+                  }}
+                  onClick={() => {
+                    setEditTest(true)
+                    setValue(0)
+                  }}
                 />
               </Tooltip>
-              <Close sx={{ margin: 2 }} onClick={() => {
-                props.close? props.close() : navigate("/testlist")
-              }} />
+              <Close
+                sx={{ margin: 2 }}
+                onClick={() => {
+                  props.close ? props.close() : navigate("/testlist")
+                }}
+              />
             </Grid>
           </Grid>
           <Grid container>
             <TabPanel value={value} index={0}>
-              <AntTabs value={valueRes} onChange={handleChangeRes} aria-label="basic tabs example">
+              <AntTabs
+                value={valueRes}
+                onChange={handleChangeRes}
+                aria-label="basic tabs example"
+              >
                 <AntTab label="Body" {...a11yProps(0)} />
                 <AntTab label="Header" {...a11yProps(1)} />
               </AntTabs>
               <Grid container direction={"row"}>
                 <TabPanel value={valueRes} index={0}>
-                  { data.httpResp?.body != null && (
-                    <Grid item container sx={{marginBottom: 10}}>
+                  {data.httpResp?.body != null && (
+                    <Grid item container sx={{ marginBottom: 10 }}>
                       {isJSON(data.httpResp.body) != "object" && (
-                        <Typography sx={{margin: 2}}>{data.httpResp.body}</Typography>
+                        <Typography sx={{ margin: 2 }}>
+                          {data.httpResp.body}
+                        </Typography>
                       )}
                       {isJSON(data.httpResp.body) == "object" && (
                         <ReactJson
@@ -118,7 +154,7 @@ export default function TcsDetail(props: TcsDetailProps) {
                       )}
                     </Grid>
                   )}
-                  { data.httpResp?.body == null && (
+                  {data.httpResp?.body == null && (
                     <List dense={true}>
                       <ListItem className={classes.listItem}>
                         <ListItemText primary={"Empty"} />
@@ -129,32 +165,43 @@ export default function TcsDetail(props: TcsDetailProps) {
               </Grid>
               <Grid container direction={"row"}>
                 <TabPanel value={valueRes} index={1}>
-                  <Grid item container  sx={{marginBottom: 10}}>
-                    {data.httpResp?.header != null && [...data.httpResp.header].map((h) => (
-                      <Grid container>
-                        <Grid item xs sx={{ padding: 1 }}>
-                          <List dense={true}>
-                            <ListItem className={classes.listItem}>
-                              <Grid container>
-                                <Grid item xs={4}>
-                                  <ListItemText primary={h.key} />
+                  <Grid item container sx={{ marginBottom: 10 }}>
+                    {data.httpResp?.header != null &&
+                      [...data.httpResp.header].map(h => (
+                        <Grid container>
+                          <Grid item xs sx={{ padding: 1 }}>
+                            <List dense={true}>
+                              <ListItem className={classes.listItem}>
+                                <Grid container>
+                                  <Grid item xs={4}>
+                                    <ListItemText primary={h.key} />
+                                  </Grid>
+                                  <Grid
+                                    item
+                                    xs={2}
+                                    container
+                                    justifyContent={"center"}
+                                  >
+                                    <ListItemText primary=":" />
+                                  </Grid>
+                                  <Grid
+                                    item
+                                    xs={6}
+                                    container
+                                    direction={"column"}
+                                  >
+                                    {[...h.value].map(eh => (
+                                      <Grid item>
+                                        <ListItemText primary={eh} />
+                                      </Grid>
+                                    ))}
+                                  </Grid>
                                 </Grid>
-                                <Grid item xs={2} container justifyContent={"center"}>
-                                  <ListItemText primary=":" />
-                                </Grid>
-                                <Grid item xs={6} container direction={"column"}>
-                                  {([...h.value].map((eh) => (
-                                    <Grid item>
-                                      <ListItemText primary={eh} />
-                                    </Grid>
-                                  )))}
-                                </Grid>
-                              </Grid>
-                            </ListItem>
-                          </List>
+                              </ListItem>
+                            </List>
+                          </Grid>
                         </Grid>
-                      </Grid>
-                    ))}
+                      ))}
                     {data.httpResp?.header == null && (
                       <List dense={true}>
                         <ListItem className={classes.listItem}>
@@ -169,22 +216,29 @@ export default function TcsDetail(props: TcsDetailProps) {
           </Grid>
           <Grid container>
             <TabPanel value={value} index={1}>
-              <AntTabs value={valueRes} onChange={handleChangeRes} aria-label="basic tabs example">
+              <AntTabs
+                value={valueRes}
+                onChange={handleChangeRes}
+                aria-label="basic tabs example"
+              >
                 <AntTab label="Body" {...a11yProps(0)} />
                 <AntTab label="Header & Info" {...a11yProps(1)} />
               </AntTabs>
               <Grid container direction={"row"}>
                 <TabPanel value={valueRes} index={0}>
-                  { data.httpReq?.body != null && (
-                    <Grid item container  sx={{marginBottom: 10}}>
+                  {data.httpReq?.body != null && (
+                    <Grid item container sx={{ marginBottom: 10 }}>
                       {isJSON(data.httpReq.body) != "object" && (
-                        <Typography sx={{margin: 2}}>{data.httpReq.body}</Typography>
+                        <Typography sx={{ margin: 2 }}>
+                          {data.httpReq.body}
+                        </Typography>
                       )}
                       {isJSON(data.httpReq.body) == "object" && (
                         <ReactJson
                           quotesOnKeys={false}
                           validationMessage={"JSON is invalid"}
-                          src={JSON.parse(data.httpReq.body)} />
+                          src={JSON.parse(data.httpReq.body)}
+                        />
                       )}
                     </Grid>
                   )}
@@ -192,24 +246,51 @@ export default function TcsDetail(props: TcsDetailProps) {
               </Grid>
               <Grid container direction={"row"}>
                 <TabPanel value={valueRes} index={1}>
-                  { data.httpReq != null && (
-                    <Grid item container direction={"column"}  sx={{marginBottom: 10}}>
+                  {data.httpReq != null && (
+                    <Grid
+                      item
+                      container
+                      direction={"column"}
+                      sx={{ marginBottom: 10 }}
+                    >
                       <Grid item sx={{ padding: 3 }}>
-                        <Typography color={"text.secondary"} variant={"subtitle1"}>Info</Typography>
+                        <Typography
+                          color={"text.secondary"}
+                          variant={"subtitle1"}
+                        >
+                          Info
+                        </Typography>
                       </Grid>
-                      <Grid item xs={8} container direction={"column"} sx={{ padding: 3 }}>
+                      <Grid
+                        item
+                        xs={8}
+                        container
+                        direction={"column"}
+                        sx={{ padding: 3 }}
+                      >
                         <List dense={true}>
                           <ListItem className={classes.listItem}>
                             <Grid container>
                               <Grid item xs={3}>
                                 <ListItemText primary={"Protocol"} />
                               </Grid>
-                              <Grid item xs={2} container justifyContent={"center"}>
+                              <Grid
+                                item
+                                xs={2}
+                                container
+                                justifyContent={"center"}
+                              >
                                 <ListItemText primary=":" />
                               </Grid>
                               <Grid item xs={7} container direction={"column"}>
                                 <Grid item>
-                                  <ListItemText primary={data.httpReq.protoMajor + "." + data.httpReq.protoMinor} />
+                                  <ListItemText
+                                    primary={
+                                      data.httpReq.protoMajor +
+                                      "." +
+                                      data.httpReq.protoMinor
+                                    }
+                                  />
                                 </Grid>
                               </Grid>
                             </Grid>
@@ -219,7 +300,12 @@ export default function TcsDetail(props: TcsDetailProps) {
                               <Grid item xs={3}>
                                 <ListItemText primary={"Method"} />
                               </Grid>
-                              <Grid item xs={2} container justifyContent={"center"}>
+                              <Grid
+                                item
+                                xs={2}
+                                container
+                                justifyContent={"center"}
+                              >
                                 <ListItemText primary=":" />
                               </Grid>
                               <Grid item xs={7} container direction={"column"}>
@@ -234,7 +320,12 @@ export default function TcsDetail(props: TcsDetailProps) {
                               <Grid item xs={3}>
                                 <ListItemText primary={"URL"} />
                               </Grid>
-                              <Grid item xs={2} container justifyContent={"center"}>
+                              <Grid
+                                item
+                                xs={2}
+                                container
+                                justifyContent={"center"}
+                              >
                                 <ListItemText primary=":" />
                               </Grid>
                               <Grid item xs={7} container direction={"column"}>
@@ -247,29 +338,45 @@ export default function TcsDetail(props: TcsDetailProps) {
                         </List>
                       </Grid>
                       <Grid item sx={{ padding: 3 }}>
-                        <Typography color={"text.secondary"} variant={"subtitle1"}>Header</Typography>
+                        <Typography
+                          color={"text.secondary"}
+                          variant={"subtitle1"}
+                        >
+                          Header
+                        </Typography>
                       </Grid>
                       <Grid item xs={8} sx={{ padding: 2 }}>
                         <List dense={true}>
-                          {data.httpReq.header != null && [...data.httpReq.header].map((h) => (
-                            <ListItem className={classes.listItem}>
-                              <Grid container>
-                                <Grid item xs={3}>
-                                  <ListItemText primary={h.key} />
+                          {data.httpReq.header != null &&
+                            [...data.httpReq.header].map(h => (
+                              <ListItem className={classes.listItem}>
+                                <Grid container>
+                                  <Grid item xs={3}>
+                                    <ListItemText primary={h.key} />
+                                  </Grid>
+                                  <Grid
+                                    item
+                                    xs={2}
+                                    container
+                                    justifyContent={"center"}
+                                  >
+                                    <ListItemText primary=":" />
+                                  </Grid>
+                                  <Grid
+                                    item
+                                    xs={7}
+                                    container
+                                    direction={"column"}
+                                  >
+                                    {[...h.value].map(eh => (
+                                      <Grid item>
+                                        <ListItemText primary={eh} />
+                                      </Grid>
+                                    ))}
+                                  </Grid>
                                 </Grid>
-                                <Grid item xs={2} container justifyContent={"center"}>
-                                  <ListItemText primary=":" />
-                                </Grid>
-                                <Grid item xs={7} container direction={"column"}>
-                                  {([...h.value].map((eh) => (
-                                    <Grid item>
-                                      <ListItemText primary={eh} />
-                                    </Grid>
-                                  )))}
-                                </Grid>
-                              </Grid>
-                            </ListItem>
-                          ))}
+                              </ListItem>
+                            ))}
                           {data.httpReq.header == null && (
                             <List dense={true}>
                               <ListItem className={classes.listItem}>
@@ -290,37 +397,54 @@ export default function TcsDetail(props: TcsDetailProps) {
               <ReactJson
                 quotesOnKeys={false}
                 validationMessage={"JSON is invalid"}
-                src={JSON.parse(JSON.stringify(data))} />
+                src={JSON.parse(JSON.stringify(data))}
+              />
             </TabPanel>
           </Grid>
-          <Grid container sx={{mb: 10}}>
+          <Grid container sx={{ mb: 10 }}>
             <TabPanel value={value} index={2}>
-              { data.deps != null && data.deps.map(d => (
-                <React.Fragment>
-                  <Typography sx={{ mt: 4, mb: 2, ml : 2 }} variant="h6" component="div">
-                    {d.name} <Typography variant={"caption"}> [ {d.type}  ] </Typography>
-                  </Typography>
-                  <List dense={true}>
-                    {d.meta?.filter(dep => (dep.key != "name" && dep.key != "type")).map(m => (
-                      <ListItem>
-                        <Grid container>
-                          <Grid item xs={3}>
-                            <ListItemText primary={m.key} />
-                          </Grid>
-                          <Grid item xs={2} container justifyContent={"center"}>
-                            <ListItemText primary=":" />
-                          </Grid>
-                          <Grid item xs={7} container direction={"column"}>
-                            <Grid item>
-                              <ListItemText primary={m.value} />
+              {data.deps != null &&
+                data.deps.map(d => (
+                  <React.Fragment>
+                    <Typography
+                      sx={{ mt: 4, mb: 2, ml: 2 }}
+                      variant="h6"
+                      component="div"
+                    >
+                      {d.name}{" "}
+                      <Typography variant={"caption"}>
+                        {" "}
+                        [ {d.type} ]{" "}
+                      </Typography>
+                    </Typography>
+                    <List dense={true}>
+                      {d.meta
+                        ?.filter(dep => dep.key != "name" && dep.key != "type")
+                        .map(m => (
+                          <ListItem>
+                            <Grid container>
+                              <Grid item xs={3}>
+                                <ListItemText primary={m.key} />
+                              </Grid>
+                              <Grid
+                                item
+                                xs={2}
+                                container
+                                justifyContent={"center"}
+                              >
+                                <ListItemText primary=":" />
+                              </Grid>
+                              <Grid item xs={7} container direction={"column"}>
+                                <Grid item>
+                                  <ListItemText primary={m.value} />
+                                </Grid>
+                              </Grid>
                             </Grid>
-                          </Grid>
-                        </Grid>
-                      </ListItem>
-                    ))}
-                  </List>
-                </React.Fragment>
-              ))}
+                          </ListItem>
+                        ))}
+                    </List>
+                  </React.Fragment>
+                ))}
               {data.deps == null && (
                 <List dense={true}>
                   <ListItem className={classes.listItem}>
@@ -332,9 +456,7 @@ export default function TcsDetail(props: TcsDetailProps) {
           </Grid>
         </React.Fragment>
       )}
-      {editTest && (
-        <EditTc tc={data} close={()=> setEditTest(false)}/>
-      )}
+      {editTest && <EditTc tc={data} close={() => setEditTest(false)} />}
     </Grid>
   )
 }

--- a/src/components/testrun/compare.tsx
+++ b/src/components/testrun/compare.tsx
@@ -1,7 +1,20 @@
 import React from "react"
-import { GET_TC_META, NORMALISE_TC, TestcaseData, TestQuery } from "../../services/queries"
+import {
+  GET_TC_META,
+  NORMALISE_TC,
+  TestcaseData,
+  TestQuery,
+} from "../../services/queries"
 import ReactDiffViewer, { DiffMethod } from "react-diff-viewer"
-import { AlertProps, Grid, List, ListItem, ListItemText, Tooltip, Typography } from "@mui/material"
+import {
+  AlertProps,
+  Grid,
+  List,
+  ListItem,
+  ListItemText,
+  Tooltip,
+  Typography,
+} from "@mui/material"
 import { CheckCircle, Close, Edit } from "@mui/icons-material"
 import { makeStyles } from "@mui/styles"
 import { isJSON } from "../../services/services"
@@ -20,43 +33,48 @@ export interface CompareViewProps {
 const useStyles = makeStyles(() => ({
   caption: {
     color: "#949393",
-    fontSize: "0.8rem !important"
+    fontSize: "0.8rem !important",
   },
   listItem: {
     margin: 3,
-    wordBreak: "break-all"
+    wordBreak: "break-all",
   },
   normal: {
-    backgroundColor: "rgb(172,242,189,0.5)"
+    backgroundColor: "rgb(172,242,189,0.5)",
   },
   error: {
     backgroundColor: "rgba(253,184,192,0.5)",
     margin: 8,
     textOverflow: "ellipsis",
     overflow: "scroll",
-    flexGrow: 1
-  }
+    flexGrow: 1,
+  },
 }))
 
 export default function CompareView(props: CompareViewProps) {
   const [value, setValue] = React.useState(0)
   const [valueRes, setResValue] = React.useState(0)
   const classes = useStyles()
-  const [openOK, setOpenOK] = React.useState(false);
+  const [openOK, setOpenOK] = React.useState(false)
   const [alert, setAlert] = React.useState<AlertProps["severity"]>(undefined)
-  const { data } = useQuery<TestcaseData>(GET_TC_META,{ variables:{id: props.test.testCaseID} })
+  const { data } = useQuery<TestcaseData>(GET_TC_META, {
+    variables: { id: props.test.testCaseID },
+  })
 
-  const [normaliseTc] = useMutation<{ normalizeTest: boolean }, { id: string }>(NORMALISE_TC, {
+  const [normaliseTc] = useMutation<
+    { normalizeTests: boolean },
+    { id: string }
+  >(NORMALISE_TC, {
     variables: {
-      id: props.test.id
-    }
+      id: props.test.id,
+    },
   })
 
   const handleClickNormalise = () => {
     normaliseTc()
-      .then((d) => {
+      .then(d => {
         if (d.data != null) {
-          if (d.data.normalizeTest) {
+          if (d.data.normalizeTests) {
             setAlert("success")
           } else {
             setAlert("error")
@@ -65,15 +83,16 @@ export default function CompareView(props: CompareViewProps) {
           setAlert("error")
         }
         return
-      }).catch((err) => {
-      console.log(err)
-      setAlert("error")
-    })
+      })
+      .catch(err => {
+        console.log(err)
+        setAlert("error")
+      })
     handleCloseOK()
   }
 
   const handleCloseOK = () => {
-    setOpenOK(false);
+    setOpenOK(false)
   }
 
   const handleChange = (_: React.SyntheticEvent, newValue: number) => {
@@ -85,83 +104,153 @@ export default function CompareView(props: CompareViewProps) {
   }
 
   return (
-    <Grid sx={{minHeight: '80vh'}}>
+    <Grid sx={{ minHeight: "80vh" }}>
       <Grid container>
         <Grid item xs={8}>
-          <AntTabs value={value} onChange={handleChange} aria-label="basic tabs example">
-            <AntTab label="Response" {...a11yProps(0)} normal={props.test.result.bodyResult.normal && (props.test.result.headersResult? props.test.result.headersResult.filter(hr => (!hr.normal)).length == 0 : true)}/>
+          <AntTabs
+            value={value}
+            onChange={handleChange}
+            aria-label="basic tabs example"
+          >
+            <AntTab
+              label="Response"
+              {...a11yProps(0)}
+              normal={
+                props.test.result.bodyResult.normal &&
+                (props.test.result.headersResult
+                  ? props.test.result.headersResult.filter(hr => !hr.normal)
+                      .length == 0
+                  : true)
+              }
+            />
             <AntTab label="Request" {...a11yProps(1)} />
             <AntTab label="Dependency" {...a11yProps(2)} />
             <AntTab label="Raw Events" {...a11yProps(3)} />
           </AntTabs>
         </Grid>
-        <Grid item xs={2} container justifyContent={"flex-end"} alignItems={"center"}>
+        <Grid
+          item
+          xs={2}
+          container
+          justifyContent={"flex-end"}
+          alignItems={"center"}
+        >
           {data != null && (
             <Tooltip title={"Edit Test Case"}>
-              <Edit sx={{
-                marginRight: 2,
-                color: "#d2d2d2",
-                ':hover': {
-                  color: 'warning.main',
-                },
-              }}
-                    onClick={()=> {
-                      navigate("/testlist/tc/?id=" + props.test.testCaseID)
-                    }}
-              />
-            </Tooltip>
-          )}
-          {data != null && !(props.test.result.bodyResult.normal && (props.test.result.headersResult? props.test.result.headersResult.filter(hr => (!hr.normal)).length == 0 : true)) && (
-            <Tooltip title={ "Accept as Normal Behaviour"}>
-              <CheckCircle
-                onClick={()=> setOpenOK(true)}
+              <Edit
                 sx={{
                   marginRight: 2,
                   color: "#d2d2d2",
-                  ':hover': {
-                    color: "#4caf50",
+                  ":hover": {
+                    color: "warning.main",
                   },
-                }}/>
+                }}
+                onClick={() => {
+                  navigate("/testlist/tc/?id=" + props.test.testCaseID)
+                }}
+              />
             </Tooltip>
           )}
-          <Close sx={{
-            marginRight: 2,
-            ':hover': {
-              color: "#851010",
-            },
-          }} onClick={() => {
-            props.close()
-          }} />
+          {data != null &&
+            !(
+              props.test.result.bodyResult.normal &&
+              (props.test.result.headersResult
+                ? props.test.result.headersResult.filter(hr => !hr.normal)
+                    .length == 0
+                : true)
+            ) && (
+              <Tooltip title={"Accept as Normal Behaviour"}>
+                <CheckCircle
+                  onClick={() => setOpenOK(true)}
+                  sx={{
+                    marginRight: 2,
+                    color: "#d2d2d2",
+                    ":hover": {
+                      color: "#4caf50",
+                    },
+                  }}
+                />
+              </Tooltip>
+            )}
+          <Close
+            sx={{
+              marginRight: 2,
+              ":hover": {
+                color: "#851010",
+              },
+            }}
+            onClick={() => {
+              props.close()
+            }}
+          />
         </Grid>
       </Grid>
       <Grid container>
         <TabPanel value={value} index={0}>
-          <AntTabs value={valueRes} onChange={handleChangeRes} aria-label="basic tabs example">
-            <AntTab label="Body" {...a11yProps(0)} normal ={props.test.result.bodyResult.normal} />
-            <AntTab label="Header" {...a11yProps(1)} normal={(props.test.result.headersResult? props.test.result.headersResult.filter(hr => (!hr.normal)).length == 0 : true)} />
+          <AntTabs
+            value={valueRes}
+            onChange={handleChangeRes}
+            aria-label="basic tabs example"
+          >
+            <AntTab
+              label="Body"
+              {...a11yProps(0)}
+              normal={props.test.result.bodyResult.normal}
+            />
+            <AntTab
+              label="Header"
+              {...a11yProps(1)}
+              normal={
+                props.test.result.headersResult
+                  ? props.test.result.headersResult.filter(hr => !hr.normal)
+                      .length == 0
+                  : true
+              }
+            />
           </AntTabs>
           <Grid container direction={"row"}>
             <TabPanel value={valueRes} index={0}>
-              { props.test.result.bodyResult != null && (
+              {props.test.result.bodyResult != null && (
                 <Grid item container>
                   <Grid item xs={6} sx={{ padding: 1 }}>
-                    <Typography className={classes.caption}>Expected Response</Typography>
+                    <Typography className={classes.caption}>
+                      Expected Response
+                    </Typography>
                   </Grid>
                   <Grid item xs={6} sx={{ padding: 1 }}>
-                    <Typography className={classes.caption}>Actual Response</Typography>
+                    <Typography className={classes.caption}>
+                      Actual Response
+                    </Typography>
                   </Grid>
                   <Grid container xs={12}>
                     <ReactDiffViewer
                       hideLineNumbers={true}
                       styles={{
                         line: {
-                          wordBreak: 'break-word',
+                          wordBreak: "break-word",
                         },
                       }}
                       noise={props.test.noise}
                       compareMethod={DiffMethod.TRIMMED_LINES}
-                      oldValue={isJSON(props.test.result.bodyResult.expected) == "object" ? JSON.stringify(JSON.parse(props.test.result.bodyResult.expected), null, 2) : props.test.result.bodyResult.expected}
-                      newValue={isJSON(props.test.result.bodyResult.actual) == "object" ? JSON.stringify(JSON.parse(props.test.result.bodyResult.actual), null, 2) : props.test.result.bodyResult.actual}
+                      oldValue={
+                        isJSON(props.test.result.bodyResult.expected) ==
+                        "object"
+                          ? JSON.stringify(
+                              JSON.parse(props.test.result.bodyResult.expected),
+                              null,
+                              2
+                            )
+                          : props.test.result.bodyResult.expected
+                      }
+                      newValue={
+                        isJSON(props.test.result.bodyResult.actual) == "object"
+                          ? JSON.stringify(
+                              JSON.parse(props.test.result.bodyResult.actual),
+                              null,
+                              2
+                            )
+                          : props.test.result.bodyResult.actual
+                      }
                       splitView={true}
                       showDiffOnly={false}
                     />
@@ -175,37 +264,52 @@ export default function CompareView(props: CompareViewProps) {
             <TabPanel value={valueRes} index={1}>
               <Grid item container>
                 <Grid item xs={6} sx={{ padding: 1 }}>
-                  <Typography className={classes.caption}>Expected Header</Typography>
+                  <Typography className={classes.caption}>
+                    Expected Header
+                  </Typography>
                 </Grid>
                 <Grid item xs={6} sx={{ padding: 1 }}>
-                  <Typography className={classes.caption}>Actual Header</Typography>
+                  <Typography className={classes.caption}>
+                    Actual Header
+                  </Typography>
                 </Grid>
-                {(props.test.result.headersResult != null) && (
-                  [...props.test.result.headersResult]?.map((h) => (
+                {props.test.result.headersResult != null &&
+                  [...props.test.result.headersResult]?.map(h => (
                     <Grid container>
                       <Grid item xs sx={{ padding: 2 }}>
                         <List dense={true}>
-                          <ListItem className={h.normal ? classes.listItem : classes.normal}>
+                          <ListItem
+                            className={
+                              h.normal ? classes.listItem : classes.normal
+                            }
+                          >
                             <Grid container>
                               <Grid item xs={4}>
-                                {h.expected.key != null && h.expected.key != "" && (
-                                  <ListItemText primary={h.expected.key} />
-                                )}
-                                {h.expected.key == null || h.expected.key == "" && (
-                                  <ListItemText primary={"Empty"} />
-                                )}
+                                {h.expected.key != null &&
+                                  h.expected.key != "" && (
+                                    <ListItemText primary={h.expected.key} />
+                                  )}
+                                {h.expected.key == null ||
+                                  (h.expected.key == "" && (
+                                    <ListItemText primary={"Empty"} />
+                                  ))}
                               </Grid>
-                              <Grid item xs={2} container justifyContent={"center"}>
+                              <Grid
+                                item
+                                xs={2}
+                                container
+                                justifyContent={"center"}
+                              >
                                 <ListItemText primary=":" />
                               </Grid>
                               <Grid item xs={6} container direction={"column"}>
                                 {h.expected.value != null && (
                                   <React.Fragment>
-                                    {([...h.expected.value].map((eh) => (
+                                    {[...h.expected.value].map(eh => (
                                       <Grid item>
                                         <ListItemText primary={eh} />
                                       </Grid>
-                                    )))}
+                                    ))}
                                   </React.Fragment>
                                 )}
                               </Grid>
@@ -215,27 +319,37 @@ export default function CompareView(props: CompareViewProps) {
                       </Grid>
                       <Grid item xs sx={{ padding: 1 }}>
                         <List dense={true}>
-                          <ListItem className={h.normal ? classes.listItem : classes.error}>
+                          <ListItem
+                            className={
+                              h.normal ? classes.listItem : classes.error
+                            }
+                          >
                             <Grid container>
                               <Grid item xs={4}>
                                 {h.actual.key != null && h.actual.key != "" && (
                                   <ListItemText primary={h.actual.key} />
                                 )}
-                                {h.actual.key == null || h.actual.key == "" && (
-                                  <ListItemText primary={"Empty"} />
-                                )}
+                                {h.actual.key == null ||
+                                  (h.actual.key == "" && (
+                                    <ListItemText primary={"Empty"} />
+                                  ))}
                               </Grid>
-                              <Grid item xs={2} container justifyContent={"center"}>
+                              <Grid
+                                item
+                                xs={2}
+                                container
+                                justifyContent={"center"}
+                              >
                                 <ListItemText primary=":" />
                               </Grid>
                               <Grid item xs={6} container direction={"column"}>
                                 {h.actual.value != null && (
                                   <React.Fragment>
-                                    {([...h.actual.value].map((eh) => (
+                                    {[...h.actual.value].map(eh => (
                                       <Grid item>
                                         <ListItemText primary={eh} />
                                       </Grid>
-                                    )))}
+                                    ))}
                                   </React.Fragment>
                                 )}
                               </Grid>
@@ -244,9 +358,11 @@ export default function CompareView(props: CompareViewProps) {
                         </List>
                       </Grid>
                     </Grid>
-                  )))}
-                {(props.test.result.headersResult == null) && (
-                  <Typography variant={"caption"} sx={{ margin: 2 }}>Empty</Typography>
+                  ))}
+                {props.test.result.headersResult == null && (
+                  <Typography variant={"caption"} sx={{ margin: 2 }}>
+                    Empty
+                  </Typography>
                 )}
               </Grid>
             </TabPanel>
@@ -255,13 +371,17 @@ export default function CompareView(props: CompareViewProps) {
       </Grid>
       <Grid container>
         <TabPanel value={value} index={1}>
-          <AntTabs value={valueRes} onChange={handleChangeRes} aria-label="basic tabs example">
+          <AntTabs
+            value={valueRes}
+            onChange={handleChangeRes}
+            aria-label="basic tabs example"
+          >
             <AntTab label="Body" {...a11yProps(0)} />
             <AntTab label="Header & Info" {...a11yProps(1)} />
           </AntTabs>
-          <Grid container direction={"row"} >
+          <Grid container direction={"row"}>
             <TabPanel value={valueRes} index={0}>
-              { props.test.req.body != null && (
+              {props.test.req.body != null && (
                 <Grid item container>
                   {isJSON(props.test.req.body) != "object" && (
                     <Typography>{props.test.req.body}</Typography>
@@ -270,7 +390,8 @@ export default function CompareView(props: CompareViewProps) {
                     <ReactJson
                       quotesOnKeys={false}
                       validationMessage={"JSON is invalid"}
-                      src={JSON.parse(props.test.req.body!)} />
+                      src={JSON.parse(props.test.req.body!)}
+                    />
                   )}
                 </Grid>
               )}
@@ -280,9 +401,17 @@ export default function CompareView(props: CompareViewProps) {
             <TabPanel value={valueRes} index={1}>
               <Grid item container direction={"column"}>
                 <Grid item sx={{ padding: 3 }}>
-                  <Typography color={"text.secondary"} variant={"subtitle1"}>Info</Typography>
+                  <Typography color={"text.secondary"} variant={"subtitle1"}>
+                    Info
+                  </Typography>
                 </Grid>
-                <Grid item xs={8} container direction={"column"} sx={{ paddingLeft: 3 }}>
+                <Grid
+                  item
+                  xs={8}
+                  container
+                  direction={"column"}
+                  sx={{ paddingLeft: 3 }}
+                >
                   <List dense={true}>
                     <ListItem className={classes.listItem}>
                       <Grid container>
@@ -294,7 +423,13 @@ export default function CompareView(props: CompareViewProps) {
                         </Grid>
                         <Grid item xs={7} container direction={"column"}>
                           <Grid item>
-                            <ListItemText primary={props.test.req.protoMajor + "." + props.test.req.protoMinor} />
+                            <ListItemText
+                              primary={
+                                props.test.req.protoMajor +
+                                "." +
+                                props.test.req.protoMinor
+                              }
+                            />
                           </Grid>
                         </Grid>
                       </Grid>
@@ -332,32 +467,41 @@ export default function CompareView(props: CompareViewProps) {
                   </List>
                 </Grid>
                 <Grid item sx={{ padding: 3 }}>
-                  <Typography color={"text.secondary"} variant={"subtitle1"}>Header</Typography>
+                  <Typography color={"text.secondary"} variant={"subtitle1"}>
+                    Header
+                  </Typography>
                 </Grid>
                 <Grid item xs={8} sx={{ padding: 2 }}>
                   <List dense={true}>
-                    {(props.test.req.header != null) && (
-                      [...props.test.req.header].map((h) => (
+                    {props.test.req.header != null &&
+                      [...props.test.req.header].map(h => (
                         <ListItem className={classes.listItem}>
                           <Grid container>
                             <Grid item xs={3}>
                               <ListItemText primary={h.key} />
                             </Grid>
-                            <Grid item xs={2} container justifyContent={"center"}>
+                            <Grid
+                              item
+                              xs={2}
+                              container
+                              justifyContent={"center"}
+                            >
                               <ListItemText primary=":" />
                             </Grid>
                             <Grid item xs={7} container direction={"column"}>
-                              {([...h.value].map((eh) => (
+                              {[...h.value].map(eh => (
                                 <Grid item>
                                   <ListItemText primary={eh} />
                                 </Grid>
-                              )))}
+                              ))}
                             </Grid>
                           </Grid>
                         </ListItem>
-                      )))}
-                    {(props.test.req.header == null) && (
-                      <Typography variant={"caption"} sx={{ margin: 2 }}>Empty</Typography>
+                      ))}
+                    {props.test.req.header == null && (
+                      <Typography variant={"caption"} sx={{ margin: 2 }}>
+                        Empty
+                      </Typography>
                     )}
                   </List>
                 </Grid>
@@ -368,33 +512,41 @@ export default function CompareView(props: CompareViewProps) {
       </Grid>
       <Grid container>
         <TabPanel value={value} index={2}>
-          { props.test.deps != null && props.test.deps.map(d => (
-            <React.Fragment>
-              <Typography sx={{ mt: 4, mb: 2, ml : 2 }} variant="h6" component="div">
-                {d.name} <Typography variant={"caption"}> [ {d.type}  ] </Typography>
-              </Typography>
-              <List dense={true}>
-                {d.meta?.filter(dep => (dep.key != "name" && dep.key != "type")).map(m => (
-                  <ListItem>
-                    <Grid container>
-                      <Grid item xs={3}>
-                        <ListItemText primary={m.key} />
-                      </Grid>
-                      <Grid item xs={2} container justifyContent={"center"}>
-                        <ListItemText primary=":" />
-                      </Grid>
-                      <Grid item xs={7} container direction={"column"}>
-                        <Grid item>
-                          <ListItemText primary={m.value} />
+          {props.test.deps != null &&
+            props.test.deps.map(d => (
+              <React.Fragment>
+                <Typography
+                  sx={{ mt: 4, mb: 2, ml: 2 }}
+                  variant="h6"
+                  component="div"
+                >
+                  {d.name}{" "}
+                  <Typography variant={"caption"}> [ {d.type} ] </Typography>
+                </Typography>
+                <List dense={true}>
+                  {d.meta
+                    ?.filter(dep => dep.key != "name" && dep.key != "type")
+                    .map(m => (
+                      <ListItem>
+                        <Grid container>
+                          <Grid item xs={3}>
+                            <ListItemText primary={m.key} />
+                          </Grid>
+                          <Grid item xs={2} container justifyContent={"center"}>
+                            <ListItemText primary=":" />
+                          </Grid>
+                          <Grid item xs={7} container direction={"column"}>
+                            <Grid item>
+                              <ListItemText primary={m.value} />
+                            </Grid>
+                          </Grid>
                         </Grid>
-                      </Grid>
-                    </Grid>
-                  </ListItem>
-                ))}
-              </List>
-            </React.Fragment>
-          ))}
-          { props.test.deps == null && (
+                      </ListItem>
+                    ))}
+                </List>
+              </React.Fragment>
+            ))}
+          {props.test.deps == null && (
             <List dense={true}>
               <ListItem className={classes.listItem}>
                 <ListItemText primary={"Empty"} />
@@ -408,16 +560,28 @@ export default function CompareView(props: CompareViewProps) {
           <ReactJson
             quotesOnKeys={false}
             validationMessage={"JSON is invalid"}
-            src={JSON.parse(JSON.stringify(props.test))} />
+            src={JSON.parse(JSON.stringify(props.test))}
+          />
         </TabPanel>
       </Grid>
-      <CustomDialog  msg={"By accepting this, the test case will be edited permanently.\n" +
-      "            Going forward the actual response of this test-case will be\n" +
-      "            the expected(normal) response. Do you still want to\n" +
-      "            continue?"}
-                     open={openOK} closefn={handleCloseOK} okfn={handleClickNormalise} title={"Use this Response as Normal Behaviour?"}/>
+      <CustomDialog
+        msg={
+          "By accepting this, the test case will be edited permanently.\n" +
+          "            Going forward the actual response of this test-case will be\n" +
+          "            the expected(normal) response. Do you still want to\n" +
+          "            continue?"
+        }
+        open={openOK}
+        closefn={handleCloseOK}
+        okfn={handleClickNormalise}
+        title={"Use this Response as Normal Behaviour?"}
+      />
       {alert != undefined && (
-        <CustomAlert msg={alert=="success"? "Test Case Updated!" : "Failed to Update!"} open={true} severity={alert}/>
+        <CustomAlert
+          msg={alert == "success" ? "Test Case Updated!" : "Failed to Update!"}
+          open={true}
+          severity={alert}
+        />
       )}
     </Grid>
   )

--- a/src/components/testrun/recent-testruns.tsx
+++ b/src/components/testrun/recent-testruns.tsx
@@ -1,5 +1,8 @@
 import React from "react"
-import { GET_RECENT_TEST_RUNS, RecentTestRunsData } from "../../services/queries"
+import {
+  GET_RECENT_TEST_RUNS,
+  RecentTestRunsData,
+} from "../../services/queries"
 import { POLLING_INTERVAL } from "../../constants"
 import SEO from "../global/seo"
 import { makeStyles } from "@mui/styles"
@@ -15,7 +18,7 @@ import {
   Tooltip,
   tooltipClasses,
   TooltipProps,
-  Typography
+  Typography,
 } from "@mui/material"
 import { navigate } from "gatsby"
 import { bgImg, convertTime } from "../../services/services"
@@ -38,180 +41,302 @@ const useStyles = makeStyles(() => ({
       boxShadow: "rgba(0, 0, 0, 0.22) 0px 19px 43px",
       transform: "translate3d(0px, -1px, 0px)",
     },
-    borderRadius: 10
+    borderRadius: 10,
   },
   key: {
     whiteSpace: "nowrap",
     overflow: "hidden",
-    color: "rgb(50,50,50)"
+    color: "rgb(50,50,50)",
   },
   value: {
     color: "rgba(25,118,210)",
     textOverflow: "ellipsis",
     overflow: "hidden",
-    flexGrow: 1
+    flexGrow: 1,
   },
   success: {
-    color: "success"
+    color: "success",
   },
   failed: {
-    color: "error"
-  }
+    color: "error",
+  },
 }))
 
 const HtmlTooltip = styled(({ className, ...props }: TooltipProps) => (
-  <Tooltip {...props} classes={{ popper: className }} />))(({}) => ({
+  <Tooltip {...props} classes={{ popper: className }} />
+))(({}) => ({
   [`& .${tooltipClasses.tooltip}`]: {
     backgroundColor: "#ffffff",
     color: "rgba(146,146,146,0.87)",
     minWidth: 250,
     marginBottom: 5,
-    border: "1px solid #dadde9"
-  }
+    border: "1px solid #dadde9",
+  },
 }))
 
 export default function RecentTestRuns() {
   const classes = useStyles()
-  const { loading, error, data } = useQuery<RecentTestRunsData>(GET_RECENT_TEST_RUNS, {
-    pollInterval: POLLING_INTERVAL,
-  })
-  if (loading) return (<Loading />)
+  const { loading, error, data } = useQuery<RecentTestRunsData>(
+    GET_RECENT_TEST_RUNS,
+    {
+      pollInterval: POLLING_INTERVAL,
+    }
+  )
+  if (loading) return <Loading />
   if (error) return <ErrorView msg={error.message} />
-  if (data == undefined || data?.testRun == undefined || data?.testRun.length == 0) {
-    return (<Empty doc={"https://github.com/keploy/keploy"} message={"Please perform some Test Runs! "} image={EmptyImg}/>)
+  if (
+    data == undefined ||
+    data?.testRun == undefined ||
+    data?.testRun.length == 0
+  ) {
+    return (
+      <Empty
+        doc={"https://github.com/keploy/keploy"}
+        message={"Please perform some Test Runs! "}
+        image={EmptyImg}
+      />
+    )
   }
 
   return (
     <React.Fragment>
       <SEO title="Recent Test Runs" />
-      <Grid container sx={{mb : 50}}>
+      <Grid container sx={{ mb: 50 }}>
         {data?.testRun.length > 0 && (
           <Grid item container direction={"column"}>
-            <AppBar position="relative" sx={{mb: 1 }} style={bgImg}>
-              <Toolbar sx={{height: '10vh', alignContent: "center"}}>
+            <AppBar position="relative" sx={{ mb: 1 }} style={bgImg}>
+              <Toolbar sx={{ height: "10vh", alignContent: "center" }}>
                 <Typography variant="h4" color="inherit" component="div">
                   Recent Test Runs
                 </Typography>
               </Toolbar>
             </AppBar>
-            <Grid item container spacing={4} sx={{pl: 5, pr: 5}}>
-              {[...data.testRun].sort((x, y) => (x.updated < y.updated) ? 1 : -1).map(k => (
-                <Grid item xs={3} container>
-                  <Card key={"card-" + k.id} className={classes.card}>
-                    <CardContent onClick={() => {
-                      navigate("/testruns/detail/?id=" + k.id)
-                    }} style={{ minHeight: 100 }}>
-                      <Grid item container direction={"row"} style={{ marginBottom: 10 }} justifyContent={"center"}>
-                        <Grid item xs={6}>
-                          <Typography variant={"subtitle2"} className={classes.key}>
-                            App
-                          </Typography>
-                        </Grid>
-                        <Grid item xs={6}>
-                          <Typography variant={"subtitle2"} className={classes.value}>
-                            : {k.app}
-                          </Typography>
-                        </Grid>
-                      </Grid>
-                      <Grid item container direction={"row"} style={{ marginBottom: 10 }} justifyContent={"center"}>
-                        <Grid item xs={6}>
-                          <Typography variant={"subtitle2"} className={classes.key}>
-                            Started at
-                          </Typography>
-                        </Grid>
-                        <Grid item xs={6}>
-                          <Typography variant={"subtitle2"} className={classes.value}>
-                            : {convertTime(k.created)}
-                          </Typography>
-                        </Grid>
-                      </Grid>
-                      <Grid item container direction={"row"} style={{ marginBottom: 10 }} justifyContent={"center"}>
-                        <Grid item xs={6}>
-                          <Typography variant={"subtitle2"} className={classes.key}>
-                            Run by
-                          </Typography>
-                        </Grid>
-                        <Grid item xs={6}>
-                          <Typography variant={"subtitle2"} className={classes.value}>
-                            : {k.user}
-                          </Typography>
-                        </Grid>
-                      </Grid>
-                    </CardContent>
-                    <CardActions style={{ marginBottom: 0 }}>
-                      <Grid container direction={"row"} style={{ alignItems: "center" }}>
-                        <Grid container style={{ justifyContent: "flex-start" }}>
-                          <Box sx={{ width: "100%" }}>
-                            <HtmlTooltip
-                              title={
-                                <React.Fragment>
-                                  <Typography>Summary</Typography>
-                                  <Grid container direction={"column"}>
-                                    <Grid item container direction={"row"} style={{ marginBottom: 10 }}
-                                          justifyContent={"center"}>
-                                      <Grid item xs={6}>
-                                        <Typography variant={"subtitle2"} color={"success.main"}>
-                                          Successful Tests
-                                        </Typography>
-                                      </Grid>
-                                      <Grid item xs={6}>
-                                        <Typography variant={"subtitle2"} color={"success.main"}>
-                                          : {k.success}
-                                        </Typography>
-                                      </Grid>
-                                    </Grid>
-                                    <Grid item container direction={"row"} style={{ marginBottom: 10 }}
-                                          justifyContent={"center"}>
-                                      <Grid item xs={6}>
-                                        <Typography variant={"subtitle2"} color={"error.main"}>
-                                          Failed Tests
-                                        </Typography>
-                                      </Grid>
-                                      <Grid item xs={6}>
-                                        <Typography variant={"subtitle2"} color={"error.main"}>
-                                          : {k.failure}
-                                        </Typography>
-                                      </Grid>
-                                    </Grid>
-                                    <Grid item container direction={"row"} style={{ marginBottom: 10 }}
-                                          justifyContent={"center"}>
-                                      <Grid item xs={6}>
-                                        <Typography variant={"subtitle2"} className={classes.value}>
-                                          Total Tests
-                                        </Typography>
-                                      </Grid>
-                                      <Grid item xs={6}>
-                                        <Typography variant={"subtitle2"} className={classes.value}>
-                                          : {k.total}
-                                        </Typography>
-                                      </Grid>
-                                    </Grid>
-                                  </Grid>
-                                </React.Fragment>
-                              }
+            <Grid item container spacing={4} sx={{ pl: 5, pr: 5 }}>
+              {[...data.testRun]
+                .sort((x, y) => (x.updated < y.updated ? 1 : -1))
+                .map(k => (
+                  <Grid item xs={3} container>
+                    <Card key={"card-" + k.id} className={classes.card}>
+                      <CardContent
+                        onClick={() => {
+                          navigate("/testruns/detail/?id=" + k.id)
+                        }}
+                        style={{ minHeight: 100 }}
+                      >
+                        <Grid
+                          item
+                          container
+                          direction={"row"}
+                          style={{ marginBottom: 10 }}
+                          justifyContent={"center"}
+                        >
+                          <Grid item xs={6}>
+                            <Typography
+                              variant={"subtitle2"}
+                              className={classes.key}
                             >
-                              <ProgressBar style={{ height: 8 }}>
-                                <ProgressBar now={(k.success * 100) / k.total} visuallyHidden={true}
-                                             style={{ height: 8, backgroundColor: "rgba(46,125,50,0.8)" }}
-                                             label={k.success + ` Successful`} key={1} />
-                                <ProgressBar now={(k.failure * 100) / k.total} visuallyHidden={true}
-                                             style={{ height: 8, backgroundColor: "rgba(211,47,47,0.8)" }}
-                                             label={k.failure + ` Failed`} key={2} />
-                                {k.status.valueOf() == "RUNNING" && (
-                                  <ProgressBar visuallyHidden={true}
-                                               now={((k.total - k.success - k.failure) * 100) / k.total}
-                                               style={{ height: 8, backgroundColor: "#fff59d", color: "#000" }}
-                                               animated striped label={`In Progress`} key={3} />
-                                )}
-                              </ProgressBar>
-                            </HtmlTooltip>
-                          </Box>
+                              App
+                            </Typography>
+                          </Grid>
+                          <Grid item xs={6}>
+                            <Typography
+                              variant={"subtitle2"}
+                              className={classes.value}
+                            >
+                              : {k.app}
+                            </Typography>
+                          </Grid>
                         </Grid>
-                      </Grid>
-                    </CardActions>
-                  </Card>
-                </Grid>
-              ))}
+                        <Grid
+                          item
+                          container
+                          direction={"row"}
+                          style={{ marginBottom: 10 }}
+                          justifyContent={"center"}
+                        >
+                          <Grid item xs={6}>
+                            <Typography
+                              variant={"subtitle2"}
+                              className={classes.key}
+                            >
+                              Started at
+                            </Typography>
+                          </Grid>
+                          <Grid item xs={6}>
+                            <Typography
+                              variant={"subtitle2"}
+                              className={classes.value}
+                            >
+                              : {convertTime(k.created)}
+                            </Typography>
+                          </Grid>
+                        </Grid>
+                        <Grid
+                          item
+                          container
+                          direction={"row"}
+                          style={{ marginBottom: 10 }}
+                          justifyContent={"center"}
+                        >
+                          <Grid item xs={6}>
+                            <Typography
+                              variant={"subtitle2"}
+                              className={classes.key}
+                            >
+                              Run by
+                            </Typography>
+                          </Grid>
+                          <Grid item xs={6}>
+                            <Typography
+                              variant={"subtitle2"}
+                              className={classes.value}
+                            >
+                              : {k.user}
+                            </Typography>
+                          </Grid>
+                        </Grid>
+                      </CardContent>
+                      <CardActions style={{ marginBottom: 0 }}>
+                        <Grid
+                          container
+                          direction={"row"}
+                          style={{ alignItems: "center" }}
+                        >
+                          <Grid
+                            container
+                            style={{ justifyContent: "flex-start" }}
+                          >
+                            <Box sx={{ width: "100%" }}>
+                              <HtmlTooltip
+                                title={
+                                  <React.Fragment>
+                                    <Typography>Summary</Typography>
+                                    <Grid container direction={"column"}>
+                                      <Grid
+                                        item
+                                        container
+                                        direction={"row"}
+                                        style={{ marginBottom: 10 }}
+                                        justifyContent={"center"}
+                                      >
+                                        <Grid item xs={6}>
+                                          <Typography
+                                            variant={"subtitle2"}
+                                            color={"success.main"}
+                                          >
+                                            Successful Tests
+                                          </Typography>
+                                        </Grid>
+                                        <Grid item xs={6}>
+                                          <Typography
+                                            variant={"subtitle2"}
+                                            color={"success.main"}
+                                          >
+                                            : {k.success}
+                                          </Typography>
+                                        </Grid>
+                                      </Grid>
+                                      <Grid
+                                        item
+                                        container
+                                        direction={"row"}
+                                        style={{ marginBottom: 10 }}
+                                        justifyContent={"center"}
+                                      >
+                                        <Grid item xs={6}>
+                                          <Typography
+                                            variant={"subtitle2"}
+                                            color={"error.main"}
+                                          >
+                                            Failed Tests
+                                          </Typography>
+                                        </Grid>
+                                        <Grid item xs={6}>
+                                          <Typography
+                                            variant={"subtitle2"}
+                                            color={"error.main"}
+                                          >
+                                            : {k.failure}
+                                          </Typography>
+                                        </Grid>
+                                      </Grid>
+                                      <Grid
+                                        item
+                                        container
+                                        direction={"row"}
+                                        style={{ marginBottom: 10 }}
+                                        justifyContent={"center"}
+                                      >
+                                        <Grid item xs={6}>
+                                          <Typography
+                                            variant={"subtitle2"}
+                                            className={classes.value}
+                                          >
+                                            Total Tests
+                                          </Typography>
+                                        </Grid>
+                                        <Grid item xs={6}>
+                                          <Typography
+                                            variant={"subtitle2"}
+                                            className={classes.value}
+                                          >
+                                            : {k.total}
+                                          </Typography>
+                                        </Grid>
+                                      </Grid>
+                                    </Grid>
+                                  </React.Fragment>
+                                }
+                              >
+                                <ProgressBar style={{ height: 8 }}>
+                                  <ProgressBar
+                                    now={(k.success * 100) / k.total}
+                                    visuallyHidden={true}
+                                    style={{
+                                      height: 8,
+                                      backgroundColor: "rgba(46,125,50,0.8)",
+                                    }}
+                                    label={k.success + ` Successful`}
+                                    key={1}
+                                  />
+                                  <ProgressBar
+                                    now={(k.failure * 100) / k.total}
+                                    visuallyHidden={true}
+                                    style={{
+                                      height: 8,
+                                      backgroundColor: "rgba(211,47,47,0.8)",
+                                    }}
+                                    label={k.failure + ` Failed`}
+                                    key={2}
+                                  />
+                                  {k.status.valueOf() == "RUNNING" && (
+                                    <ProgressBar
+                                      visuallyHidden={true}
+                                      now={
+                                        ((k.total - k.success - k.failure) *
+                                          100) /
+                                        k.total
+                                      }
+                                      style={{
+                                        height: 8,
+                                        backgroundColor: "#fff59d",
+                                        color: "#000",
+                                      }}
+                                      animated
+                                      striped
+                                      label={`In Progress`}
+                                      key={3}
+                                    />
+                                  )}
+                                </ProgressBar>
+                              </HtmlTooltip>
+                            </Box>
+                          </Grid>
+                        </Grid>
+                      </CardActions>
+                    </Card>
+                  </Grid>
+                ))}
             </Grid>
           </Grid>
         )}

--- a/src/components/testrun/test-tab.tsx
+++ b/src/components/testrun/test-tab.tsx
@@ -11,7 +11,7 @@ import {
   GridToolbarContainer,
   GridToolbarDensitySelector,
   GridToolbarFilterButton,
-  MuiEvent
+  MuiEvent,
 } from "@mui/x-data-grid"
 import { Box, Chip, IconButton } from "@mui/material"
 import { Check, Close, HourglassEmpty } from "@mui/icons-material"
@@ -22,6 +22,8 @@ import { defaultTq } from "../../constants"
 export interface TestTabProps {
   tests: TestQuery[]
   editMode: boolean
+  setTestDetail: React.Dispatch<React.SetStateAction<TestQuery>>
+  testDetail: TestQuery
 }
 
 export interface TestRow {
@@ -49,25 +51,34 @@ function renderStatus(params: GridRenderCellParams<TestStatus>) {
   let startIcon = <HourglassEmpty color={"warning"} />
 
   switch (params.value.valueOf()) {
-    case "PASSED" : {
+    case "PASSED": {
       styleClass = "success"
       startIcon = <Check color={"success"} />
       break
     }
-    case "FAILED" : {
+    case "FAILED": {
       styleClass = "error"
       startIcon = <Close color={"error"} />
       break
     }
   }
 
-  return <Chip sx={{ minWidth: "30%" }} variant="outlined" color={styleClass}
-               avatar={<IconButton>{startIcon}</IconButton>} label={params.value} />
+  return (
+    <Chip
+      sx={{ minWidth: "30%" }}
+      variant="outlined"
+      color={styleClass}
+      avatar={<IconButton>{startIcon}</IconButton>}
+      label={params.value}
+    />
+  )
 }
 
 export default function TestTab(props: TestTabProps) {
+  const { testDetail, setTestDetail } = props
   const rows: TestRow[] = getRows(props.tests)
-  const [selectionModel, setSelectionModel] = React.useState<GridSelectionModel>([])
+  const [selectionModel, setSelectionModel] =
+    React.useState<GridSelectionModel>([])
   const [pageSize, setPageSize] = React.useState<number>(25)
   const columns: GridColDef[] = [
     {
@@ -77,7 +88,7 @@ export default function TestTab(props: TestTabProps) {
       flex: 1,
       headerClassName: "super-app-theme--header",
       align: "left",
-      headerAlign: "left"
+      headerAlign: "left",
     },
     {
       field: "proto",
@@ -85,7 +96,7 @@ export default function TestTab(props: TestTabProps) {
       minWidth: 150,
       headerClassName: "super-app-theme--header",
       align: "center",
-      headerAlign: "center"
+      headerAlign: "center",
     },
     {
       field: "dependencyTypes",
@@ -94,7 +105,7 @@ export default function TestTab(props: TestTabProps) {
       flex: 1,
       headerClassName: "super-app-theme--header",
       align: "center",
-      headerAlign: "center"
+      headerAlign: "center",
     },
     {
       field: "statusCode",
@@ -103,7 +114,7 @@ export default function TestTab(props: TestTabProps) {
       flex: 1,
       headerClassName: "super-app-theme--header",
       align: "center",
-      headerAlign: "center"
+      headerAlign: "center",
     },
     {
       field: "status",
@@ -113,63 +124,85 @@ export default function TestTab(props: TestTabProps) {
       headerClassName: "super-app-theme--header",
       align: "center",
       headerAlign: "center",
-      renderCell: renderStatus
-    }
+      renderCell: renderStatus,
+    },
   ]
-  const [testDetail, setTestDetail] = React.useState<TestQuery>(defaultTq)
+  // const [testDetail, setTestDetail] = React.useState<TestQuery>(defaultTq)
 
   return (
-    <Box sx={{
-      width: "100%", backgroundColor: "white",
-      "& .super-app-theme--header": {
-        backgroundColor: "rgba(25,118,210,0.9)",
-        color: "#ffffff"
-      }
-    }}>
+    <Box
+      sx={{
+        width: "100%",
+        backgroundColor: "white",
+        "& .super-app-theme--header": {
+          backgroundColor: "rgba(25,118,210,0.9)",
+          color: "#ffffff",
+        },
+      }}
+    >
       {testDetail.id == "" && (
         <React.Fragment>
           {!props.editMode && (
-            <DataGrid rows={rows} columns={columns}
-                      pageSize={pageSize}
-                      onPageSizeChange={(newPageSize) => setPageSize(newPageSize)}
-                      rowsPerPageOptions={[25, 50, 100]}
-                      pagination
-                      autoHeight={true}
-                      isRowSelectable={(params: GridRowParams) => params.row["status"] == TestStatus.FAILED}
-                      onRowClick={(params: GridRowParams, event: MuiEvent<React.MouseEvent>) => {
-                        event.defaultMuiPrevented = true
-                        let t = props.tests.filter((item) => item.id == params.id)
-                        setTestDetail(t[0])
-                      }}
-                      components={{ Toolbar: CustomToolbar }} />
+            <DataGrid
+              rows={rows}
+              columns={columns}
+              pageSize={pageSize}
+              onPageSizeChange={newPageSize => setPageSize(newPageSize)}
+              rowsPerPageOptions={[25, 50, 100]}
+              pagination
+              autoHeight={true}
+              isRowSelectable={(params: GridRowParams) =>
+                params.row["status"] == TestStatus.FAILED
+              }
+              onRowClick={(
+                params: GridRowParams,
+                event: MuiEvent<React.MouseEvent>
+              ) => {
+                event.defaultMuiPrevented = true
+                let t = props.tests.filter(item => item.id == params.id)
+                //sdsadsadds//
+                setTestDetail(t[0])
+              }}
+              components={{ Toolbar: CustomToolbar }}
+            />
           )}
-
           {props.editMode && (
-            <DataGrid rows={rows} columns={columns}
-                      pageSize={pageSize}
-                      onPageSizeChange={(newPageSize) => setPageSize(newPageSize)}
-                      rowsPerPageOptions={[25, 50, 100]}
-                      pagination
-                      autoHeight={true}
-                      checkboxSelection={true}
-                      isRowSelectable={(params: GridRowParams) => params.row["status"] == TestStatus.FAILED}
-                      onRowClick={(params: GridRowParams, event: MuiEvent<React.MouseEvent>) => {
-                        event.defaultMuiPrevented = true
-                        let t = props.tests.filter((item) => item.id == params.id)
-                        setTestDetail(t[0])
-                      }}
-                      onSelectionModelChange={(newSelectionModel) => {
-                        setSelectionModel(newSelectionModel)
-                      }}
-                      selectionModel={selectionModel}
-                      components={{ Toolbar: CustomToolbar }} />
+            <DataGrid
+              rows={rows}
+              columns={columns}
+              pageSize={pageSize}
+              onPageSizeChange={newPageSize => setPageSize(newPageSize)}
+              rowsPerPageOptions={[25, 50, 100]}
+              pagination
+              autoHeight={true}
+              checkboxSelection={true}
+              isRowSelectable={(params: GridRowParams) =>
+                params.row["status"] == TestStatus.FAILED
+              }
+              onRowClick={(
+                params: GridRowParams,
+                event: MuiEvent<React.MouseEvent>
+              ) => {
+                event.defaultMuiPrevented = true
+                let t = props.tests.filter(item => item.id == params.id)
+                setTestDetail(t[0])
+              }}
+              onSelectionModelChange={newSelectionModel => {
+                setSelectionModel(newSelectionModel)
+              }}
+              selectionModel={selectionModel}
+              components={{ Toolbar: CustomToolbar }}
+            />
           )}
         </React.Fragment>
       )}
       {testDetail.id != "" && (
-        <CompareView test={testDetail} close={() => {
-          setTestDetail(defaultTq)
-        }} />
+        <CompareView
+          test={testDetail}
+          close={() => {
+            setTestDetail(defaultTq)
+          }}
+        />
       )}
     </Box>
   )

--- a/src/components/testrun/testrun-detail.tsx
+++ b/src/components/testrun/testrun-detail.tsx
@@ -1,10 +1,22 @@
 import React from "react"
-import { Avatar, Card, CardContent, CardHeader, Grid, Tabs, Typography } from "@mui/material"
+import {
+  Avatar,
+  Card,
+  CardContent,
+  CardHeader,
+  Grid,
+  Tabs,
+  Typography,
+} from "@mui/material"
 import SEO from "../global/seo"
 import { makeStyles } from "@mui/styles"
 import TestTab from "./test-tab"
 import { GET_TEST_RUN_DETAIL, TestRunData } from "../../services/queries"
-import { convertTime, getStatusColor, getTestForURL } from "../../services/services"
+import {
+  convertTime,
+  getStatusColor,
+  getTestForURL,
+} from "../../services/services"
 import Empty from "../global/empty"
 // @ts-ignore
 import EmptyImg from "../../../static/empty2.png"
@@ -12,6 +24,8 @@ import Loading from "../global/backdrop"
 import ErrorView from "../global/error"
 import { useQuery } from "@apollo/client"
 import { a11yProps, CustomTab, TabPanelBox } from "../global/tab-panel"
+import { defaultTq } from "../../constants"
+import { TestQuery } from "../../services/queries"
 
 export interface TestRunDetailProps {
   testRunID: string
@@ -25,25 +39,39 @@ const useStyles = makeStyles(() => ({
   tabs: {
     minWidth: "100%",
     borderRight: `1px solid #00000`,
-    marginTop: 10
+    marginTop: 10,
   },
   caption: {
-    color: "#949393"
+    color: "#949393",
   },
   url: {
     margin: 2,
-    wordBreak: "break-all"
-  }
+    wordBreak: "break-all",
+  },
 }))
 
 export default function TestRunDetail(props: TestRunDetailProps) {
   const classes = useStyles()
   const [value, setValue] = React.useState(0)
-  const { loading, error, data } = useQuery<TestRunData>(GET_TEST_RUN_DETAIL, { variables: { id: props.testRunID } })
-  if (loading) return (<Loading />)
+  const [testDetail, setTestDetail] = React.useState<TestQuery>(defaultTq)
+  const { loading, error, data } = useQuery<TestRunData>(GET_TEST_RUN_DETAIL, {
+    variables: { id: props.testRunID },
+  })
+  if (loading) return <Loading />
   if (error) return <ErrorView msg={error.message} />
-  if (data == undefined || data?.testRun == undefined || data?.testRun[0].tests == undefined || data?.testRun[0].tests?.length == 0) {
-    return (<Empty doc={"https://github.com/keploy/keploy"} message={"Please wait while we run test cases for you! "} image={EmptyImg}/>)
+  if (
+    data == undefined ||
+    data?.testRun == undefined ||
+    data?.testRun[0].tests == undefined ||
+    data?.testRun[0].tests?.length == 0
+  ) {
+    return (
+      <Empty
+        doc={"https://github.com/keploy/keploy"}
+        message={"Please wait while we run test cases for you! "}
+        image={EmptyImg}
+      />
+    )
   }
 
   let urlData = getTestForURL(data.testRun[0].tests)
@@ -63,21 +91,48 @@ export default function TestRunDetail(props: TestRunDetailProps) {
               value={value}
               onChange={handleChange}
               aria-label="Vertical tabs endpoints"
-              className={classes.tabs}>
+              className={classes.tabs}
+            >
               {[...urlData.keys()].map((e, i) => (
                 <CustomTab
-                  key={e} label={<React.Fragment>
-                  <Grid container direction={"column"}>
-                    <Grid item container>
-                      <Grid item xs={6}> <Typography> {urlData.get(e)![0].req.method}</Typography></Grid>
-                      <Grid item xs={6} container justifyContent={"flex-end"}>
-                        <Typography className={classes.caption}>{urlData.get(e)!.length} tests</Typography></Grid>
-                    </Grid>
-                    <Grid item>
-                      <Typography className={classes.url}>{urlData.get(e)![0].uri}</Typography>
-                    </Grid>
-                  </Grid>
-                </React.Fragment>} {...a11yProps(i)} />
+                  key={e}
+                  label={
+                    <React.Fragment>
+                      <Grid
+                        container
+                        direction={"column"}
+                        // dfsdfsdf
+                        onClick={() => setTestDetail(defaultTq)}
+                      >
+                        <Grid item container>
+                          <Grid item xs={6}>
+                            {" "}
+                            <Typography>
+                              {" "}
+                              {urlData.get(e)![0].req.method}
+                            </Typography>
+                          </Grid>
+                          <Grid
+                            item
+                            xs={6}
+                            container
+                            justifyContent={"flex-end"}
+                          >
+                            <Typography className={classes.caption}>
+                              {urlData.get(e)!.length} tests
+                            </Typography>
+                          </Grid>
+                        </Grid>
+                        <Grid item>
+                          <Typography className={classes.url}>
+                            {urlData.get(e)![0].uri}
+                          </Typography>
+                        </Grid>
+                      </Grid>
+                    </React.Fragment>
+                  }
+                  {...a11yProps(i)}
+                />
               ))}
             </Tabs>
           </Grid>
@@ -86,7 +141,13 @@ export default function TestRunDetail(props: TestRunDetailProps) {
           <Card sx={{ width: "98%", marginLeft: 1.5 }}>
             <CardHeader
               avatar={
-                <Avatar sx={{ bgcolor: "#" + ((1 << 24) * Math.random() | 0).toString(16) }} aria-label="recipe">
+                <Avatar
+                  sx={{
+                    bgcolor:
+                      "#" + (((1 << 24) * Math.random()) | 0).toString(16),
+                  }}
+                  aria-label="recipe"
+                >
                   {data.testRun[0].user.charAt(0)}
                 </Avatar>
               }
@@ -94,29 +155,46 @@ export default function TestRunDetail(props: TestRunDetailProps) {
               subheader={convertTime(data.testRun[0].created)}
             />
             <CardContent>
-              <Grid container direction={"row"} justifyContent={"space-between"}>
+              <Grid
+                container
+                direction={"row"}
+                justifyContent={"space-between"}
+              >
                 <Grid item xs={3}>
                   <Typography color={"primary"}>Total Tests </Typography>
-                  <Typography color={"info.main"}>{data.testRun[0].total}</Typography>
+                  <Typography color={"info.main"}>
+                    {data.testRun[0].total}
+                  </Typography>
                 </Grid>
                 <Grid item xs={3}>
                   <Typography color={"primary"}>Passed </Typography>
-                  <Typography color={"success.main"}>{data.testRun[0].success}</Typography>
+                  <Typography color={"success.main"}>
+                    {data.testRun[0].success}
+                  </Typography>
                 </Grid>
                 <Grid item xs={3}>
                   <Typography color={"primary"}>Failed </Typography>
-                  <Typography color={"error"}>{data.testRun[0].failure}</Typography>
+                  <Typography color={"error"}>
+                    {data.testRun[0].failure}
+                  </Typography>
                 </Grid>
                 <Grid item xs={3}>
                   <Typography color={"primary"}>Status </Typography>
-                  <Typography color={getStatusColor(data.testRun[0].status)}>{data.testRun[0].status}</Typography>
+                  <Typography color={getStatusColor(data.testRun[0].status)}>
+                    {data.testRun[0].status}
+                  </Typography>
                 </Grid>
               </Grid>
             </CardContent>
           </Card>
           {[...urlData.keys()].map((k, i) => (
             <TabPanelBox key={k} value={value} index={i}>
-              <TestTab tests={urlData.get(k)!} editMode={false} />
+              <TestTab
+                tests={urlData.get(k)!}
+                editMode={false}
+                setTestDetail={setTestDetail}
+                testDetail={testDetail}
+              />
             </TabPanelBox>
           ))}
         </Grid>


### PR DESCRIPTION
…id-containing-test-runs): Issue fix #25

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

### Description
<!-- Add a brief description of the pull request -->
UX improvements Now user can click the tab and go back to the data grid containing test runs

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->