### PR TITLE
fix(testrun-detail): Go back to default view using tabs 

### DIFF
--- a/src/components/testrun/test-tab.tsx
+++ b/src/components/testrun/test-tab.tsx
@@ -22,6 +22,8 @@ import { defaultTq } from "../../constants"
 export interface TestTabProps {
   tests: TestQuery[]
   editMode: boolean
+  setTestDetail: React.Dispatch<React.SetStateAction<TestQuery>>
+  testDetail: TestQuery
 }
 
 export interface TestRow {
@@ -49,12 +51,12 @@ function renderStatus(params: GridRenderCellParams<TestStatus>) {
   let startIcon = <HourglassEmpty color={"warning"} />
 
   switch (params.value.valueOf()) {
-    case "PASSED" : {
+    case "PASSED": {
       styleClass = "success"
       startIcon = <Check color={"success"} />
       break
     }
-    case "FAILED" : {
+    case "FAILED": {
       styleClass = "error"
       startIcon = <Close color={"error"} />
       break
@@ -62,10 +64,11 @@ function renderStatus(params: GridRenderCellParams<TestStatus>) {
   }
 
   return <Chip sx={{ minWidth: "30%" }} variant="outlined" color={styleClass}
-               avatar={<IconButton>{startIcon}</IconButton>} label={params.value} />
+    avatar={<IconButton>{startIcon}</IconButton>} label={params.value} />
 }
 
 export default function TestTab(props: TestTabProps) {
+  const { testDetail, setTestDetail } = props
   const rows: TestRow[] = getRows(props.tests)
   const [selectionModel, setSelectionModel] = React.useState<GridSelectionModel>([])
   const [pageSize, setPageSize] = React.useState<number>(25)
@@ -116,7 +119,6 @@ export default function TestTab(props: TestTabProps) {
       renderCell: renderStatus
     }
   ]
-  const [testDetail, setTestDetail] = React.useState<TestQuery>(defaultTq)
 
   return (
     <Box sx={{
@@ -130,39 +132,39 @@ export default function TestTab(props: TestTabProps) {
         <React.Fragment>
           {!props.editMode && (
             <DataGrid rows={rows} columns={columns}
-                      pageSize={pageSize}
-                      onPageSizeChange={(newPageSize) => setPageSize(newPageSize)}
-                      rowsPerPageOptions={[25, 50, 100]}
-                      pagination
-                      autoHeight={true}
-                      isRowSelectable={(params: GridRowParams) => params.row["status"] == TestStatus.FAILED}
-                      onRowClick={(params: GridRowParams, event: MuiEvent<React.MouseEvent>) => {
-                        event.defaultMuiPrevented = true
-                        let t = props.tests.filter((item) => item.id == params.id)
-                        setTestDetail(t[0])
-                      }}
-                      components={{ Toolbar: CustomToolbar }} />
+              pageSize={pageSize}
+              onPageSizeChange={(newPageSize) => setPageSize(newPageSize)}
+              rowsPerPageOptions={[25, 50, 100]}
+              pagination
+              autoHeight={true}
+              isRowSelectable={(params: GridRowParams) => params.row["status"] == TestStatus.FAILED}
+              onRowClick={(params: GridRowParams, event: MuiEvent<React.MouseEvent>) => {
+                event.defaultMuiPrevented = true
+                let t = props.tests.filter((item) => item.id == params.id)
+                setTestDetail(t[0])
+              }}
+              components={{ Toolbar: CustomToolbar }} />
           )}
 
           {props.editMode && (
             <DataGrid rows={rows} columns={columns}
-                      pageSize={pageSize}
-                      onPageSizeChange={(newPageSize) => setPageSize(newPageSize)}
-                      rowsPerPageOptions={[25, 50, 100]}
-                      pagination
-                      autoHeight={true}
-                      checkboxSelection={true}
-                      isRowSelectable={(params: GridRowParams) => params.row["status"] == TestStatus.FAILED}
-                      onRowClick={(params: GridRowParams, event: MuiEvent<React.MouseEvent>) => {
-                        event.defaultMuiPrevented = true
-                        let t = props.tests.filter((item) => item.id == params.id)
-                        setTestDetail(t[0])
-                      }}
-                      onSelectionModelChange={(newSelectionModel) => {
-                        setSelectionModel(newSelectionModel)
-                      }}
-                      selectionModel={selectionModel}
-                      components={{ Toolbar: CustomToolbar }} />
+              pageSize={pageSize}
+              onPageSizeChange={(newPageSize) => setPageSize(newPageSize)}
+              rowsPerPageOptions={[25, 50, 100]}
+              pagination
+              autoHeight={true}
+              checkboxSelection={true}
+              isRowSelectable={(params: GridRowParams) => params.row["status"] == TestStatus.FAILED}
+              onRowClick={(params: GridRowParams, event: MuiEvent<React.MouseEvent>) => {
+                event.defaultMuiPrevented = true
+                let t = props.tests.filter((item) => item.id == params.id)
+                setTestDetail(t[0])
+              }}
+              onSelectionModelChange={(newSelectionModel) => {
+                setSelectionModel(newSelectionModel)
+              }}
+              selectionModel={selectionModel}
+              components={{ Toolbar: CustomToolbar }} />
           )}
         </React.Fragment>
       )}

--- a/src/components/testrun/testrun-detail.tsx
+++ b/src/components/testrun/testrun-detail.tsx
@@ -12,7 +12,8 @@ import Loading from "../global/backdrop"
 import ErrorView from "../global/error"
 import { useQuery } from "@apollo/client"
 import { a11yProps, CustomTab, TabPanelBox } from "../global/tab-panel"
-
+import { defaultTq } from "../../constants"
+import { TestQuery } from "../../services/queries"
 export interface TestRunDetailProps {
   testRunID: string
 }
@@ -39,11 +40,12 @@ const useStyles = makeStyles(() => ({
 export default function TestRunDetail(props: TestRunDetailProps) {
   const classes = useStyles()
   const [value, setValue] = React.useState(0)
+  const [testDetail, setTestDetail] = React.useState<TestQuery>(defaultTq)
   const { loading, error, data } = useQuery<TestRunData>(GET_TEST_RUN_DETAIL, { variables: { id: props.testRunID } })
   if (loading) return (<Loading />)
   if (error) return <ErrorView msg={error.message} />
   if (data == undefined || data?.testRun == undefined || data?.testRun[0].tests == undefined || data?.testRun[0].tests?.length == 0) {
-    return (<Empty doc={"https://github.com/keploy/keploy"} message={"Please wait while we run test cases for you! "} image={EmptyImg}/>)
+    return (<Empty doc={"https://github.com/keploy/keploy"} message={"Please wait while we run test cases for you! "} image={EmptyImg} />)
   }
 
   let urlData = getTestForURL(data.testRun[0].tests)
@@ -67,17 +69,17 @@ export default function TestRunDetail(props: TestRunDetailProps) {
               {[...urlData.keys()].map((e, i) => (
                 <CustomTab
                   key={e} label={<React.Fragment>
-                  <Grid container direction={"column"}>
-                    <Grid item container>
-                      <Grid item xs={6}> <Typography> {urlData.get(e)![0].req.method}</Typography></Grid>
-                      <Grid item xs={6} container justifyContent={"flex-end"}>
-                        <Typography className={classes.caption}>{urlData.get(e)!.length} tests</Typography></Grid>
+                    <Grid container direction={"column"} onClick={() => setTestDetail(defaultTq)}>
+                      <Grid item container>
+                        <Grid item xs={6}> <Typography> {urlData.get(e)![0].req.method}</Typography></Grid>
+                        <Grid item xs={6} container justifyContent={"flex-end"}>
+                          <Typography className={classes.caption}>{urlData.get(e)!.length} tests</Typography></Grid>
+                      </Grid>
+                      <Grid item>
+                        <Typography className={classes.url}>{urlData.get(e)![0].uri}</Typography>
+                      </Grid>
                     </Grid>
-                    <Grid item>
-                      <Typography className={classes.url}>{urlData.get(e)![0].uri}</Typography>
-                    </Grid>
-                  </Grid>
-                </React.Fragment>} {...a11yProps(i)} />
+                  </React.Fragment>} {...a11yProps(i)} />
               ))}
             </Tabs>
           </Grid>
@@ -116,7 +118,7 @@ export default function TestRunDetail(props: TestRunDetailProps) {
           </Card>
           {[...urlData.keys()].map((k, i) => (
             <TabPanelBox key={k} value={value} index={i}>
-              <TestTab tests={urlData.get(k)!} editMode={false} />
+              <TestTab tests={urlData.get(k)!} editMode={false} setTestDetail={setTestDetail} testDetail={testDetail} />
             </TabPanelBox>
           ))}
         </Grid>


### PR DESCRIPTION
Go back to default view using tabs

UX improvement

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

### Description
<!-- Add a brief description of the pull request -->
now user can click on tab buttons on a particular test run case and go back to default view
<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->