### PR TITLE
Update documentation to show the correct command for dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ export GATSBY_API_URL=http://localhost:8081/api
 Now let's start the Gatsby Server 
 
 ```shell
-gatsby develop
+npm run develop
 ```
 
 If you make some UI/design changes and want to add test data. In the new directory, clone test data repo : 


### PR DESCRIPTION
## Description

This change allows users that dont have gatsby cli installed globally to use it through the local instance.

## Type of change

Please delete options that are not relevant.

- [X] This change requires a documentation update.

## How Has This Been Tested?

Have a look at the Github Readme.md


## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have made corresponding changes to the documentation.
- [ ] I have added corresponding tests.
- [ ] Any dependent changes have been merged and published in downstream modules.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
