### PR TITLE
fix: normalise-test-query-and-it's-use-in-testruns

### DIFF
--- a/src/components/testrun/compare.tsx
+++ b/src/components/testrun/compare.tsx
@@ -46,9 +46,9 @@ export default function CompareView(props: CompareViewProps) {
   const [alert, setAlert] = React.useState<AlertProps["severity"]>(undefined)
   const { data } = useQuery<TestcaseData>(GET_TC_META,{ variables:{id: props.test.testCaseID} })
 
-  const [normaliseTc] = useMutation<{ normalizeTest: boolean }, { id: string }>(NORMALISE_TC, {
+  const [normaliseTc] = useMutation<{ normalizeTests: boolean }, { ids: string[] }>(NORMALISE_TC, {
     variables: {
-      id: props.test.id
+      ids: props.test.id.split(" "),
     }
   })
 
@@ -56,7 +56,7 @@ export default function CompareView(props: CompareViewProps) {
     normaliseTc()
       .then((d) => {
         if (d.data != null) {
-          if (d.data.normalizeTest) {
+          if (d.data.normalizeTests) {
             setAlert("success")
           } else {
             setAlert("error")

--- a/src/services/queries.ts
+++ b/src/services/queries.ts
@@ -251,8 +251,8 @@ query getTc ($app : String!) {
 `
 
 export const NORMALISE_TC = gql`
-  mutation normalizeTest( $id: String!) {
-    normalizeTest(id: $id) 
+  mutation normalizeTests( $ids: [String!]!) {
+    normalizeTests(ids: $ids) 
   }
 `
 


### PR DESCRIPTION
Seems like the feature of normalising multiple test cases on the backend broke the frontend graphql API since the schema changed

Introduced during - keploy/keploy#68

# Pull Request Template

## Description

This fixes https://github.com/keploy/ui/issues/61

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding tests.
- [ ] Any dependent changes have been merged and published in downstream modules.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
