### PR TITLE
docs(readme): update keploy port from 8081 to 6789

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ npm i
 ```
 For development, we'll add the API URL as local keploy server url running at http://localhost:6789
 ```shell
-export GATSBY_API_URL=http://localhost:8081/api
+export GATSBY_API_URL=http://localhost:6879/api
 ```
 
 Now let's start the Gatsby Server 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ docker-compose -f docker-compose-dev.yaml up --build
 git clone https://github.com/keploy/ui.git && cd ui
 npm i 
 ```
-For development, we'll add the API URL as local keploy server url running at http://localhost:8081
+For development, we'll add the API URL as local keploy server url running at http://localhost:6789
 ```shell
 export GATSBY_API_URL=http://localhost:8081/api
 ```


### PR DESCRIPTION
## Description

We've updated deploy's default port from `8081` to `6789`. This PR updates that in the README. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue).

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Additional Context (Please include any Screenshots/gifs if relevant)

...

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding tests.
- [x] Any dependent changes have been merged and published in downstream modules.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
