### PR TITLE
Updates broken docker-compose links in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This is the UI repository of Keploy platform. Please follow [QuickStart/Installa
 Make sure you're using **Node version 17.x.x**
 
 ### 1. Start the Keploy Server
-There's a separate [docker-compose](docker-compose-dev.yaml) file which helps which exposes the mongo server and also builds the dockerfile from local code.  The `build` flag ensures that the binary is built again to reflect the latest code changes. There's also [docker-compose-debug.yaml](docker-compose-debug.yaml) which can help remote debugging the go server on port 4000.
+There's a separate [docker-compose](https://github.com/keploy/keploy/blob/main/docker-compose-dev.yaml) file which helps which exposes the mongo server and also builds the dockerfile from local code.  The `build` flag ensures that the binary is built again to reflect the latest code changes. There's also [docker-compose-debug.yaml](https://github.com/keploy/keploy/blob/main/docker-compose-debug.yaml) which can help remote debugging the go server on port 40000.
 ```shell
 git clone https://github.com/keploy/keploy.git && cd keploy
 docker-compose -f docker-compose-dev.yaml up --build


### PR DESCRIPTION
# Updates broken docker-compose links in documentation

## Description

This MR fixes broken docker-compose links in the README doc.

Fixes https://github.com/keploy/ui/issues/97

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).

## How Has This Been Tested?

Links are no longer broken.

## Additional Context (Please include any Screenshots/gifs if relevant)

Hacktoberfest contribution

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding tests.
- [x] Any dependent changes have been merged and published in downstream modules.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
